### PR TITLE
Delete comment

### DIFF
--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -4,7 +4,6 @@
 # https://github.com/uphyca/dockerfiles/android
 #
 
-# Pull small base image.
 FROM debian:jessie
 
 


### PR DESCRIPTION
> :app:mergeDebugResourcesAAPT err(Facade for 29882146):
> /opt/android-sdk-linux/build-tools/24.0.0/aapt:
> /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.14' not found
> (required by /opt/android-sdk-linux/build-tools/24.0.0/aapt)

This is for android-24 support.
